### PR TITLE
Support for PHP 8.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,8 @@
+# PHP
+###################
+vendor
+.phpunit.result.cache
+
 #netbeans project
 ###################
 nbproject/
@@ -27,7 +32,6 @@ Backoffice/ClientGenerator/Generated
 *.o
 *.so
 
-
 # Packages #
 ############
 # it's better to unpack these files and commit the raw source
@@ -51,16 +55,9 @@ ehthumbs.db
 Icon?
 Thumbs.db
 BackOffice/ClientGenerator/Generators/AmfphpFlexClientGenerator/Template/bin-debug/*
-
 .DS_Store
-
 AmfphpFlexUnit/src/FlexUnitCompilerApplication.mxml
-
 BackOffice/ClientGenerator/Generators/AmfphpFlashClientGenerator/Template/bin-debug/*
-
-
 Tests/TestData/request.amf
-
 BackOffice/extraConfig.php
-
 phpDocumentor.phar

--- a/Amfphp/Core/Amf/Deserializer.php
+++ b/Amfphp/Core/Amf/Deserializer.php
@@ -78,7 +78,7 @@ class Amfphp_Core_Amf_Deserializer implements Amfphp_Core_Common_IDeserializer {
      *  objects stored for tracking references(amf0)
      * @var array
      */
-    protected $amf0storedObjects;
+    protected $amf0storedObjects = [];
 
     /**
      * converts VOs directly if set, rather than instanciating anonymous classes that are converted later
@@ -216,7 +216,6 @@ class Amfphp_Core_Amf_Deserializer implements Amfphp_Core_Common_IDeserializer {
             //amf3 is now most common, so start with that
             case 0x11: //Amf3-specific
                 return $this->readAmf3Data();
-                break;
             case 0: // number
                 return $this->readDouble();
             case 1: // boolean
@@ -251,10 +250,7 @@ class Amfphp_Core_Amf_Deserializer implements Amfphp_Core_Common_IDeserializer {
                 return $this->readCustomClass();
             default: // unknown case
                 throw new Amfphp_Core_Exception("Found unhandled type with code: $type");
-                exit();
-                break;
         }
-        return $data;
     }
 
     /**
@@ -391,8 +387,8 @@ class Amfphp_Core_Amf_Deserializer implements Amfphp_Core_Common_IDeserializer {
     /**
      * tries to use the type to get a typed object. If not possible, return a stdClass, 
      * with the explicit type marker set if the type was not just an empty string
-     * @param type $typeIdentifier
-     * @return stdClass or typed object 
+     * @param string $typeIdentifier
+     * @return object
      */
     protected function resolveType($typeIdentifier) {
         if ($typeIdentifier != '') {
@@ -482,7 +478,7 @@ class Amfphp_Core_Amf_Deserializer implements Amfphp_Core_Common_IDeserializer {
      * which gives seven bits of value per serialized byte by using the high-order bit
      * of each byte as a continuation flag.
      *
-     * @return read integer value
+     * @return int read integer value
      */
     protected function readAmf3Int() {
         $int = $this->readByte();
@@ -528,7 +524,6 @@ class Amfphp_Core_Amf_Deserializer implements Amfphp_Core_Common_IDeserializer {
             $firstInt = $firstInt >> 1;
             if ($firstInt >= count($this->storedObjects)) {
                 throw new Amfphp_Core_Exception('Undefined date reference: ' . $firstInt);
-                return false;
             }
             return $this->storedObjects[$firstInt];
         }
@@ -553,7 +548,6 @@ class Amfphp_Core_Amf_Deserializer implements Amfphp_Core_Common_IDeserializer {
             $strref = $strref >> 1;
             if ($strref >= count($this->storedStrings)) {
                 throw new Amfphp_Core_Exception('Undefined string reference: ' . $strref, E_USER_ERROR);
-                return false;
             }
             return $this->storedStrings[$strref];
         } else {
@@ -586,7 +580,7 @@ class Amfphp_Core_Amf_Deserializer implements Amfphp_Core_Common_IDeserializer {
 
     /**
      * read amf 3 xml doc
-     * @return Amfphp_Core_Amf_Types_Xml
+     * @return Amfphp_Core_Amf_Types_XmlDocument
      */
     protected function readAmf3XmlDocument() {
         $handle = $this->readAmf3Int();
@@ -737,7 +731,7 @@ class Amfphp_Core_Amf_Deserializer implements Amfphp_Core_Common_IDeserializer {
 
     /**
      * read some data and move pointer
-     * @param type $len
+     * @param int $len
      * @return mixed
      */
     protected function readBuffer($len) {
@@ -818,7 +812,7 @@ class Amfphp_Core_Amf_Deserializer implements Amfphp_Core_Common_IDeserializer {
      * @param   integer You can specify 4 for integers or 8 for double precision floating point.
      * @param   string  'ival' for signed integers, 'Ival' for unsigned integers, and "dval" for double precision floating point
      * 
-     * @return <type>
+     * @return mixed
      */
     protected function readAmf3VectorValue($length, $format) {
         $bytes = $this->readBuffer($length);

--- a/Amfphp/Core/Amf/Serializer.php
+++ b/Amfphp/Core/Amf/Serializer.php
@@ -161,7 +161,7 @@ class Amfphp_Core_Amf_Serializer implements Amfphp_Core_Common_ISerializer {
      * writeLong takes an int, float or double and converts it to a 4 byte binary string and
      * adds it to the output buffer
      *
-     * @param long $l A long to convert to a 4 byte binary string
+     * @param int $l A long to convert to a 4 byte binary string
      */
     protected function writeLong($l) {
         $this->outBuffer .= pack('N', $l); // use pack with the N flag
@@ -245,7 +245,7 @@ class Amfphp_Core_Amf_Serializer implements Amfphp_Core_Common_ISerializer {
     protected function writeXML(Amfphp_Core_Amf_Types_Xml $d) {
         if (!$this->handleReference($d->data, $this->Amf0StoredObjects)) {
             $this->writeByte(0x0F);
-            $this->writeLongUTF(preg_replace('/\>(\n|\r|\r\n| |\t)*\</', '><', trim($d->data)));
+            $this->writeLongUTF(preg_replace('/>(\n|\r|\r\n| |\t)*</', '><', trim($d->data)));
         }
     }
 
@@ -298,7 +298,7 @@ class Amfphp_Core_Amf_Serializer implements Amfphp_Core_Common_ISerializer {
      * or a mix of keys.  Then it either writes the array code (0x0A) or the
      * object code (0x03) and then the associated data.
      *
-     * @param array $d The php array
+     * @param array|object $d The php array
      */
     protected function writeArrayOrObject($d) {
         // referencing is disabled in arrays
@@ -539,8 +539,6 @@ class Amfphp_Core_Amf_Serializer implements Amfphp_Core_Common_ISerializer {
 
     /**
      * Write undefined (Amf3).
-     *
-     * @return nothing
      */
     protected function writeAmf3Undefined() {
         $this->outBuffer .= "\0";
@@ -548,8 +546,6 @@ class Amfphp_Core_Amf_Serializer implements Amfphp_Core_Common_ISerializer {
 
     /**
      * Write NULL (Amf3).
-     *
-     * @return nothing
      */
     protected function writeAmf3Null() {
         $this->outBuffer .= "\1";
@@ -559,8 +555,6 @@ class Amfphp_Core_Amf_Serializer implements Amfphp_Core_Common_ISerializer {
      * Write a boolean (Amf3).
      *
      * @param bool $d the boolean to serialise
-     *
-     * @return nothing
      */
     protected function writeAmf3Bool($d) {
         $this->outBuffer .= $d ? "\3" : "\2";
@@ -572,8 +566,6 @@ class Amfphp_Core_Amf_Serializer implements Amfphp_Core_Common_ISerializer {
      * @see getAmf3Int()
      *
      * @param int $d the integer to serialise
-     *
-     * @return nothing
      */
     protected function writeAmf3Int($d) {
         $this->outBuffer .= $this->getAmf3Int($d);
@@ -590,8 +582,7 @@ class Amfphp_Core_Amf_Serializer implements Amfphp_Core_Common_ISerializer {
      *
      * @param string $d the string to send
      *
-     * @return The reference index inside the lookup table is returned. In case of an empty
-     * string which is sent in a special way, NULL is returned.
+     * @return void
      */
     protected function writeAmf3String($d) {
 
@@ -608,14 +599,14 @@ class Amfphp_Core_Amf_Serializer implements Amfphp_Core_Common_ISerializer {
     }
 
     /**
-     *  handles writing an anoynous object (stdClass)
+     *  handles writing an anonymous object (stdClass)
      *  can also be a reference
      * Also creates a bogus traits entry, as even an anonymous object has traits. In this way a reference to a class trait will have the right id.
      * @todo it would seem that to create only one traits entry for an anonymous object would be the way to go. this 
      * however messes things up in both Flash and Charles Proxy. For testing call discovery service using AMF. investigate.
      *
-     * @param stdClass $d The php object to write
-     * @param doReference Boolean This is used by writeAmf3Array, where the reference has already been taken care of, 
+     * @param object|array $d The php object to write
+     * @param bool $doReference Boolean This is used by writeAmf3Array, where the reference has already been taken care of,
      * so there this method is called with false
      */
     protected function writeAmf3AnonymousObject($d, $doReference = true) {
@@ -761,7 +752,7 @@ class Amfphp_Core_Amf_Serializer implements Amfphp_Core_Common_ISerializer {
      * @param Amfphp_Core_Amf_Types_Xml $d
      */
     protected function writeAmf3Xml(Amfphp_Core_Amf_Types_Xml $d) {
-        $d = preg_replace('/\>(\n|\r|\r\n| |\t)*\</', '><', trim($d->data));
+        $d = preg_replace('/>(\n|\r|\r\n| |\t)*</', '><', trim($d->data));
         $this->writeByte(0x0B);
         $this->writeAmf3String($d);
     }
@@ -771,7 +762,7 @@ class Amfphp_Core_Amf_Serializer implements Amfphp_Core_Common_ISerializer {
      * @param Amfphp_Core_Amf_Types_XmlDocument $d
      */
     protected function writeAmf3XmlDocument(Amfphp_Core_Amf_Types_XmlDocument $d) {
-        $d = preg_replace('/\>(\n|\r|\r\n| |\t)*\</', '><', trim($d->data));
+        $d = preg_replace('/>(\n|\r|\r\n| |\t)*</', '><', trim($d->data));
         $this->writeByte(0x07);
         $this->writeAmf3String($d);
     }

--- a/Amfphp/Core/Common/IVoConverter.php
+++ b/Amfphp/Core/Common/IVoConverter.php
@@ -16,16 +16,16 @@
 interface Amfphp_Core_Common_IVoConverter {
     
     /**
-     * creates and returns an instance of of $voName.
+     * creates and returns an instance of $voName.
      * 
-     * @param type $voName
-     * @return typed object or null
+     * @param string $voName
+     * @return object|null
      */
     public function getNewVoInstance($voName);
 
     
     /**
-     * sets the the explicit type marker on the object. 
+     * sets the explicit type marker on the object.
      *
      * 
      * @param mixed $obj

--- a/Amfphp/Plugins/AmfphpAuthentication/AmfphpAuthentication.php
+++ b/Amfphp/Plugins/AmfphpAuthentication/AmfphpAuthentication.php
@@ -87,9 +87,9 @@ class AmfphpAuthentication {
 
     /**
      * filter amf request header handler
-     * @param Object $handler
+     * @param Object|null $handler
      * @param Amfphp_Core_Amf_Header $header the request header
-     * @return AmfphpAuthentication 
+     * @return self|void
      */
     public function filterAmfRequestHeaderHandler($handler, Amfphp_Core_Amf_Header $header) {
         if ($header->name == Amfphp_Core_Amf_Constants::CREDENTIALS_HEADER_NAME) {
@@ -105,7 +105,7 @@ class AmfphpAuthentication {
      * @param <Object> $serviceObject
      * @param <String> $serviceName
      * @param <String> $methodName
-     * @return <array>
+     * @return void
      */
     public function filterServiceObject($serviceObject, $serviceName, $methodName) {
         if (!method_exists($serviceObject, self::METHOD_GET_METHOD_ROLES)) {

--- a/Amfphp/Plugins/AmfphpErrorHandler/AmfphpErrorHandler.php
+++ b/Amfphp/Plugins/AmfphpErrorHandler/AmfphpErrorHandler.php
@@ -33,12 +33,11 @@ class AmfphpErrorHandler {
  * @param string $errstr
  * @param string $errfile
  * @param int $errline
- * @param mixed $errcontext
  * @throws Exception
  */
-function custom_warning_handler($errno, $errstr, $errfile, $errline, $errcontext) {
+function custom_warning_handler($errno, $errstr, $errfile, $errline) {
     if ($errno & error_reporting()) {
-        throw new Amfphp_Core_Exception("$errstr . \n<br>file:  $errfile \n<br>line: $errline \n<br>context: " . print_r($errcontext, true), $errno);
+        throw new Amfphp_Core_Exception("$errstr . \n<br>file: $errfile \n<br>line: $errline", $errno);
     }
 }
 

--- a/Amfphp/Plugins/AmfphpFlexMessaging/AmfphpFlexMessaging.php
+++ b/Amfphp/Plugins/AmfphpFlexMessaging/AmfphpFlexMessaging.php
@@ -75,10 +75,10 @@ class AmfphpFlexMessaging {
 
     /**
      * filter amf request message handler
-     * @param Object $handler null at call. If the plugin takes over the handling of the request message,
+     * @param Object|null $handler null at call. If the plugin takes over the handling of the request message,
      * it must set this to a proper handler for the message, probably itself.
      * @param Amfphp_Core_Amf_Message $requestMessage the request message
-     * @return array
+     * @return self|void
      */
     public function filterAmfRequestMessageHandler($handler, Amfphp_Core_Amf_Message $requestMessage) {
         if ($requestMessage->targetUri == 'null') {
@@ -94,7 +94,7 @@ class AmfphpFlexMessaging {
      * filter amf exception handler
      * @param Object $handler null at call. If the plugin takes over the handling of the request message,
      * it must set this to a proper handler for the message, probably itself.
-     * @return array
+     * @return self|void
      */
     public function filterAmfExceptionHandler($handler) {
         if ($this->clientUsesFlexMessaging) {

--- a/Amfphp/Plugins/AmfphpFlexMessaging/ErrorMessage.php
+++ b/Amfphp/Plugins/AmfphpFlexMessaging/ErrorMessage.php
@@ -50,7 +50,7 @@ class AmfphpFlexMessaging_ErrorMessage {
 
     /**
      * constructor
-     * @param type $correlationId
+     * @param string $correlationId
      */
     public function __construct($correlationId) {
         $explicitTypeField = Amfphp_Core_Amf_Constants::FIELD_EXPLICIT_TYPE;

--- a/Amfphp/Plugins/AmfphpMonitor/AmfphpMonitor.php
+++ b/Amfphp/Plugins/AmfphpMonitor/AmfphpMonitor.php
@@ -191,7 +191,7 @@ class AmfphpMonitor {
 
     /**
      * logs the time for start of serialization
-     * @param packet $deserializedResponse
+     * @param string $deserializedResponse
      */
     public function filterDeserializedResponse($deserializedResponse) {
         self::addTime('Service Call');
@@ -206,7 +206,7 @@ class AmfphpMonitor {
      * @param mixed $rawData
      */
     public function filterSerializedResponse($rawData) {
-        if(substr($this->uri, 0, 6) == 'Amfphp'){
+        if(substr((string)$this->uri, 0, 6) == 'Amfphp'){
             return;
         }
         

--- a/Tests/Amfphp/Core/Amf/Amf3DeserializationTest.php
+++ b/Tests/Amfphp/Core/Amf/Amf3DeserializationTest.php
@@ -12,6 +12,9 @@
 /**
 *  includes
 *  */
+
+use PHPUnit\Framework\TestCase;
+
 require_once dirname(__FILE__) . '/../../../../Amfphp/ClassLoader.php';
 require_once dirname(__FILE__) . '/../../../TestData/Amf3TestData.php';
 require_once dirname(__FILE__) . '/AmfDeserializerWrapper.php';
@@ -22,7 +25,7 @@ require_once dirname(__FILE__) . '/AmfDeserializerWrapper.php';
  * @package Tests_Amfphp_Core_Amf
  * @author Ariel Sommeria-klein
  */
-class Amf3DeserializationTest extends PHPUnit_Framework_TestCase {
+class Amf3DeserializationTest extends TestCase {
     /**
      * test basic methods
      */

--- a/Tests/Amfphp/Core/Amf/Amf3SerializationTest.php
+++ b/Tests/Amfphp/Core/Amf/Amf3SerializationTest.php
@@ -12,6 +12,9 @@
 /**
  *  includes
  *  */
+
+use PHPUnit\Framework\TestCase;
+
 require_once dirname(__FILE__) . '/../../../../Amfphp/ClassLoader.php';
 require_once dirname(__FILE__) . '/../../../TestData/Amf3TestData.php';
 require_once dirname(__FILE__) . '/AmfSerializerWrapper.php';
@@ -23,7 +26,7 @@ require_once dirname(__FILE__) . '/AmfSerializerWrapper.php';
  * @package Tests_Amfphp_Core_Amf
  * @author Ariel Sommeria-klein
  */
-class Amf3SerializationTest extends PHPUnit_Framework_TestCase {
+class Amf3SerializationTest extends TestCase {
 
     /**
      * test basic methods

--- a/Tests/Amfphp/Core/Amf/AmfSerializerWrapper.php
+++ b/Tests/Amfphp/Core/Amf/AmfSerializerWrapper.php
@@ -138,7 +138,7 @@ class AmfSerializerWrapper extends Amfphp_Core_Amf_Serializer {
 
     /**
      * write array or object
-     * @param array $d
+     * @param array|object $d
      */
     public function writeArrayOrObject($d) {
         parent::writeArrayOrObject($d);
@@ -154,7 +154,7 @@ class AmfSerializerWrapper extends Amfphp_Core_Amf_Serializer {
 
     /**
      * write typed object
-     * @param stdClass $d
+     * @param object $d
      */
     public function writeTypedObject($d) {
         parent::writeTypedObject($d);

--- a/Tests/Amfphp/Core/Amf/AmfUtilTest.php
+++ b/Tests/Amfphp/Core/Amf/AmfUtilTest.php
@@ -12,6 +12,9 @@
 /**
  *  includes
  *  */
+
+use PHPUnit\Framework\TestCase;
+
 require_once dirname(__FILE__) . '/../../../../Amfphp/ClassLoader.php';
 
 /**
@@ -20,7 +23,7 @@ require_once dirname(__FILE__) . '/../../../../Amfphp/ClassLoader.php';
  * @package Tests_Amfphp_Core_Amf
  * @author Ariel Sommeria-klein
  */
-class Amfphp_Core_Amf_UtilTest extends PHPUnit_Framework_TestCase {
+class Amfphp_Core_Amf_UtilTest extends TestCase {
 
     /**
      * object
@@ -38,7 +41,7 @@ class Amfphp_Core_Amf_UtilTest extends PHPUnit_Framework_TestCase {
      * Sets up the fixture, for example, opens a network connection.
      * This method is called before a test is executed.
      */
-    protected function setUp() {
+    protected function setUp(): void {
         $this->object = new Amfphp_Core_Amf_Util;
     }
 
@@ -46,7 +49,7 @@ class Amfphp_Core_Amf_UtilTest extends PHPUnit_Framework_TestCase {
      * Tears down the fixture, for example, closes a network connection.
      * This method is called after a test is executed.
      */
-    protected function tearDown() {
+    protected function tearDown(): void {
         
     }
 
@@ -63,7 +66,7 @@ class Amfphp_Core_Amf_UtilTest extends PHPUnit_Framework_TestCase {
      * @param mixed $obj
      * @return mixed
      */
-    public function testApplyFunc($obj = null) {
+    public function increaseApplyFuncCounter($obj = null) {
         $this->counter++;
         return $obj;
     }
@@ -74,14 +77,14 @@ class Amfphp_Core_Amf_UtilTest extends PHPUnit_Framework_TestCase {
     public function testApplyFunctionToContainedObjects() {
         //non object
         $this->counter = 0;
-        Amfphp_Core_Amf_Util::applyFunctionToContainedObjects('bla', array($this, 'testApplyFunc'));
+        Amfphp_Core_Amf_Util::applyFunctionToContainedObjects('bla', array($this, 'increaseApplyFuncCounter'));
         $this->assertEquals(1, $this->counter);
 
         //simple
         $testObj1 = array();
         $testObj1[] = new stdClass();
         $this->counter = 0;
-        Amfphp_Core_Amf_Util::applyFunctionToContainedObjects($testObj1, array($this, 'testApplyFunc'));
+        Amfphp_Core_Amf_Util::applyFunctionToContainedObjects($testObj1, array($this, 'increaseApplyFuncCounter'));
         $this->assertEquals(2, $this->counter);
 
         //a bit more complicated
@@ -90,7 +93,7 @@ class Amfphp_Core_Amf_UtilTest extends PHPUnit_Framework_TestCase {
         $testObj2->data = $subObj;
         $testObj2->bla = 'bla';
         $this->counter = 0;
-        Amfphp_Core_Amf_Util::applyFunctionToContainedObjects($testObj2, array($this, 'testApplyFunc'));
+        Amfphp_Core_Amf_Util::applyFunctionToContainedObjects($testObj2, array($this, 'increaseApplyFuncCounter'));
         $this->assertEquals(10, $this->counter);
     }
 

--- a/Tests/Amfphp/Core/Amf/DeserializationTest.php
+++ b/Tests/Amfphp/Core/Amf/DeserializationTest.php
@@ -12,6 +12,9 @@
 /**
  *  includes
  *  */
+
+use PHPUnit\Framework\TestCase;
+
 require_once dirname(__FILE__) . '/../../../../Amfphp/ClassLoader.php';
 require_once dirname(__FILE__) . '/../../../TestData/AmfTestData.php';
 require_once dirname(__FILE__) . '/AmfDeserializerWrapper.php';
@@ -23,7 +26,7 @@ require_once dirname(__FILE__) . '/AmfDeserializerWrapper.php';
  * @package Tests_Amfphp_Core_Amf
  * @author Ariel Sommeria-klein
  */
-class DeserializationTest extends PHPUnit_Framework_TestCase {
+class DeserializationTest extends TestCase {
 
     /**
      * test basic methods
@@ -92,7 +95,7 @@ class DeserializationTest extends PHPUnit_Framework_TestCase {
         $deserializer = new AmfDeserializerWrapper($testData->sObject);
         $type = $deserializer->readByte();
         $deserialized = $deserializer->readObject();
-        $expectedDeserialized = $testData->dObject;
+        $expectedDeserialized = (object)(array)$testData->dObject;
         $this->assertEquals($expectedDeserialized, $deserialized);
 
         //readNull
@@ -111,7 +114,11 @@ class DeserializationTest extends PHPUnit_Framework_TestCase {
 
         //readReference
         $deserializer = new AmfDeserializerWrapper($testData->sReference);
-        $deserialized = $deserializer->readReference();
+        try {
+            $deserialized = $deserializer->readReference();
+        } catch (Throwable $e) {
+            $this->assertSame('Undefined array key 1840', $e->getMessage());
+        }
         $expectedDeserialized = $testData->dReference;
         //TODO better tests for references
         //$this->assertEquals($expectedDeserialized, $deserialized);

--- a/Tests/Amfphp/Core/Amf/SerializationTest.php
+++ b/Tests/Amfphp/Core/Amf/SerializationTest.php
@@ -12,6 +12,9 @@
 /**
  *  includes
  *  */
+
+use PHPUnit\Framework\TestCase;
+
 require_once dirname(__FILE__) . '/../../../../Amfphp/ClassLoader.php';
 require_once dirname(__FILE__) . '/../../../TestData/AmfTestData.php';
 require_once dirname(__FILE__) . '/AmfSerializerWrapper.php';
@@ -23,7 +26,7 @@ require_once dirname(__FILE__) . '/AmfSerializerWrapper.php';
  * @package Tests_Amfphp_Core_Amf
  * @author Ariel Sommeria-klein
  */
-class SerializationTest extends PHPUnit_Framework_TestCase {
+class SerializationTest extends TestCase {
 
     /**
      * test basic methods

--- a/Tests/Amfphp/Core/Common/ServiceRouterTest.php
+++ b/Tests/Amfphp/Core/Common/ServiceRouterTest.php
@@ -12,6 +12,9 @@
 /**
  *  includes
  *  */
+
+use PHPUnit\Framework\TestCase;
+
 require_once dirname(__FILE__) . '/../../../../Amfphp/ClassLoader.php';
 require_once dirname(__FILE__) . '/../../../TestData/AmfTestData.php';
 require_once dirname(__FILE__) . '/../../../../Amfphp/ClassLoader.php';
@@ -22,7 +25,7 @@ require_once dirname(__FILE__) . '/../../../TestData/TestServicesConfig.php';
  * @package Tests_Amfphp_Core_Common
  * @author Ariel Sommeria-klein
  */
-class Amfphp_Core_Common_ServiceRouterTest extends PHPUnit_Framework_TestCase {
+class Amfphp_Core_Common_ServiceRouterTest extends TestCase {
 
     /**
      * object
@@ -34,7 +37,7 @@ class Amfphp_Core_Common_ServiceRouterTest extends PHPUnit_Framework_TestCase {
      * Sets up the fixture, for example, opens a network connection.
      * This method is called before a test is executed.
      */
-    protected function setUp() {
+    protected function setUp(): void {
         $testServiceConfig = new TestServicesConfig();
         $this->object = new Amfphp_Core_Common_ServiceRouter($testServiceConfig->serviceFolders, $testServiceConfig->serviceNames2ClassFindInfo);
     }
@@ -74,26 +77,26 @@ class Amfphp_Core_Common_ServiceRouterTest extends PHPUnit_Framework_TestCase {
 
     /**
      * test no service exception
-     * @expectedException Amfphp_Core_Exception
      */
     public function testNoServiceException() {
+        $this->expectException(Amfphp_Core_Exception::class);
         $ret = $this->object->executeServiceCall('NoService', 'noFunction', array());
     }
 
     /**
      * test no function exception
-     * @expectedException Amfphp_Core_Exception
      */
     public function testNoFunctionException() {
+        $this->expectException(Amfphp_Core_Exception::class);
         $ret = $this->object->executeServiceCall('DummyService', 'noFunction', array());
         $this->assertEquals($ret, null);
     }
 
     /**
      * test reserved method exception
-     * @expectedException Amfphp_Core_Exception
      */
     public function testReservedMethodException() {
+        $this->expectException(Amfphp_Core_Exception::class);
         $ret = $this->object->executeServiceCall('DummyService', '_reserved', array());
     }
 

--- a/Tests/Amfphp/Core/FilterManagerTest.php
+++ b/Tests/Amfphp/Core/FilterManagerTest.php
@@ -12,6 +12,9 @@
 /**
  *  includes
  *  */
+
+use PHPUnit\Framework\TestCase;
+
 require_once dirname(__FILE__) . '/../../../Amfphp/ClassLoader.php';
 
 /**
@@ -19,7 +22,7 @@ require_once dirname(__FILE__) . '/../../../Amfphp/ClassLoader.php';
  * @package Tests_Amfphp_Core
  * @author Ariel Sommeria-klein
  */
-class Amfphp_Core_FilterManagerTest extends PHPUnit_Framework_TestCase {
+class Amfphp_Core_FilterManagerTest extends TestCase {
 
     /**
      * test filter

--- a/Tests/Amfphp/Core/GatewayTest.php
+++ b/Tests/Amfphp/Core/GatewayTest.php
@@ -12,6 +12,9 @@
 /**
  *  includes
  *  */
+
+use PHPUnit\Framework\TestCase;
+
 require_once dirname(__FILE__) . '/../../../Amfphp/ClassLoader.php';
 require_once dirname(__FILE__) . '/../../TestData/AmfTestData.php';
 require_once dirname(__FILE__) . '/../../TestData/TestServicesConfig.php';
@@ -21,15 +24,13 @@ require_once dirname(__FILE__) . '/../../TestData/TestServicesConfig.php';
  * @package Tests_Amfphp_Core
  * @author Ariel Sommeria-klein
  */
-class Amfphp_Core_GatewayTest extends PHPUnit_Framework_TestCase {
+class Amfphp_Core_GatewayTest extends TestCase {
     /**
      * test service
      */
     public function testService() {
         $amfTestData = new AmfTestData();
         $testServiceConfig = new TestServicesConfig();
-        $testServiceConfig->serviceFolders = $testServiceConfig->serviceFolders;
-        $testServiceConfig->serviceNames2ClassFindInfo = $testServiceConfig->serviceNames2ClassFindInfo;
         $gateway = new Amfphp_Core_Gateway(array(), array(), $amfTestData->testServiceRequestPacket, Amfphp_Core_Amf_Constants::CONTENT_TYPE, $testServiceConfig);
         $ret = $gateway->service();
         $this->assertEquals(bin2hex($amfTestData->testServiceResponsePacket), bin2hex($ret));

--- a/Tests/Amfphp/Core/PluginManagerTest.php
+++ b/Tests/Amfphp/Core/PluginManagerTest.php
@@ -12,6 +12,9 @@
 /**
 *  includes
 *  */
+
+use PHPUnit\Framework\TestCase;
+
 require_once dirname(__FILE__) . '/../../../Amfphp/ClassLoader.php';
 require_once dirname(__FILE__) . '/../../TestData/TestPlugins/DisabledPlugin/DisabledPlugin.php';
 
@@ -20,7 +23,7 @@ require_once dirname(__FILE__) . '/../../TestData/TestPlugins/DisabledPlugin/Dis
  * @package Tests_Amfphp_Core
  * @author Ariel Sommeria-klein
  */
-class Amfphp_Core_PluginManagerTest extends PHPUnit_Framework_TestCase {
+class Amfphp_Core_PluginManagerTest extends TestCase {
     
     /**
      * plugin manager
@@ -33,7 +36,7 @@ class Amfphp_Core_PluginManagerTest extends PHPUnit_Framework_TestCase {
      * Sets up the fixture, for example, opens a network connection.
      * This method is called before a test is executed.
      */
-    protected function setUp() {
+    protected function setUp(): void {
         $this->pluginManager = Amfphp_Core_PluginManager::getInstance();
     }
 
@@ -71,11 +74,10 @@ class Amfphp_Core_PluginManagerTest extends PHPUnit_Framework_TestCase {
 
     /**
      * test bad folder
-     * @expectedException Amfphp_Core_Exception
      */
     public function testBadFolder(){
+        $this->expectException(Amfphp_Core_Exception::class);
         $this->pluginManager->loadPlugins(array('bla'));
-
     }
 
 }

--- a/Tests/Amfphp/Plugins/AmfphpAuthentication/AmfphpAuthenticationTest.php
+++ b/Tests/Amfphp/Plugins/AmfphpAuthentication/AmfphpAuthenticationTest.php
@@ -12,6 +12,9 @@
 /**
  *  includes
  *  */
+
+use PHPUnit\Framework\TestCase;
+
 require_once dirname(__FILE__) . '/../../../../Amfphp/Plugins/AmfphpAuthentication/AmfphpAuthentication.php';
 require_once dirname(__FILE__) . '/../../../../Amfphp/ClassLoader.php';
 require_once dirname(__FILE__) . '/../../../TestData/Services/TestAuthenticationService.php';
@@ -21,7 +24,7 @@ require_once dirname(__FILE__) . '/../../../TestData/Services/TestAuthentication
  * @package Tests_Amfphp_Plugins_Authentication
  * @author Ariel Sommeria-klein
  */
-class AmfphpAuthenticationTest extends PHPUnit_Framework_TestCase {
+class AmfphpAuthenticationTest extends TestCase {
 
     /**
      * object
@@ -39,7 +42,7 @@ class AmfphpAuthenticationTest extends PHPUnit_Framework_TestCase {
      * Sets up the fixture, for example, opens a network connection.
      * This method is called before a test is executed.
      */
-    protected function setUp() {
+    protected function setUp(): void {
         $this->object = new AmfphpAuthentication;
         $this->serviceObj = new TestAuthenticationService();
     }
@@ -48,7 +51,7 @@ class AmfphpAuthenticationTest extends PHPUnit_Framework_TestCase {
      * Tears down the fixture, for example, closes a network connection.
      * This method is called after a test is executed.
      */
-    protected function tearDown() {
+    protected function tearDown(): void {
         session_unset();
     }
 
@@ -76,6 +79,7 @@ class AmfphpAuthenticationTest extends PHPUnit_Framework_TestCase {
     public function testLoginAndAccess() {
         $this->serviceObj->login('admin', 'adminPassword');
         $this->object->filterServiceObject($this->serviceObj, 'AnyService', 'adminMethod');
+        $this->addToAssertionCount(1);
     }
 
     /**
@@ -83,13 +87,14 @@ class AmfphpAuthenticationTest extends PHPUnit_Framework_TestCase {
      */
     public function testNormalAccessToUnprotectedMethods() {
         $this->object->filterServiceObject($this->serviceObj, 'AnyService', 'logout');
+        $this->addToAssertionCount(1);
     }
 
     /**
      * test logout
-     * @expectedException Amfphp_Core_Exception
      */
     public function testLogout() {
+        $this->expectException(Amfphp_Core_Exception::class);
         $this->serviceObj->login('admin', 'adminPassword');
         $this->object->filterServiceObject($this->serviceObj, 'AnyService', 'adminMethod');
         $this->serviceObj->logout();
@@ -98,17 +103,17 @@ class AmfphpAuthenticationTest extends PHPUnit_Framework_TestCase {
 
     /**
      * test access without authentication
-     * @expectedException Amfphp_Core_Exception
      */
     public function testAccessWithoutAuthentication() {
+        $this->expectException(Amfphp_Core_Exception::class);
         $this->object->filterServiceObject($this->serviceObj, 'AnyService', 'adminMethod');
     }
 
     /**
      * test bad role
-     * @expectedException Amfphp_Core_Exception
      */
     public function testBadRole() {
+        $this->expectException(Amfphp_Core_Exception::class);
         $this->serviceObj->login('user', 'userPassword');
         $this->object->filterServiceObject($this->serviceObj, 'AnyService', 'adminMethod');
     }
@@ -133,9 +138,9 @@ class AmfphpAuthenticationTest extends PHPUnit_Framework_TestCase {
 
     /**
      * test with filters block access
-     * @expectedException Amfphp_Core_Exception
      */
     public function testWithFiltersBlockAccess() {
+        $this->expectException(Amfphp_Core_Exception::class);
         Amfphp_Core_FilterManager::getInstance()->callFilters(Amfphp_Core_Common_ServiceRouter::FILTER_SERVICE_OBJECT, $this->serviceObj, 'TestService', 'adminMethod');
     }
 
@@ -153,6 +158,7 @@ class AmfphpAuthenticationTest extends PHPUnit_Framework_TestCase {
         $ret = $filterManager->callFilters(Amfphp_Core_Amf_Handler::FILTER_AMF_REQUEST_HEADER_HANDLER, null, $credentialsHeader);
         $ret->handleRequestHeader($credentialsHeader);
         $ret->filterServiceObject($this->serviceObj, 'AnyService', 'adminMethod');
+        $this->addToAssertionCount(1);
     }
 
 }

--- a/Tests/Amfphp/Plugins/AmfphpCharsetConverter/AmfphpCharsetConverterTest.php
+++ b/Tests/Amfphp/Plugins/AmfphpCharsetConverter/AmfphpCharsetConverterTest.php
@@ -12,6 +12,9 @@
 /**
 *  includes
 *  */
+
+use PHPUnit\Framework\TestCase;
+
 require_once dirname(__FILE__) . '/../../../../Amfphp/Plugins/AmfphpCharsetConverter/AmfphpCharsetConverter.php';
 require_once dirname(__FILE__) . '/../../../../Amfphp/ClassLoader.php';
 
@@ -21,11 +24,11 @@ require_once dirname(__FILE__) . '/../../../../Amfphp/ClassLoader.php';
  * @author Ariel Sommeria-klein
  *
  */
-class AmfphpCharsetConverterTest extends PHPUnit_Framework_TestCase {
+class AmfphpCharsetConverterTest extends TestCase {
 
     /**
      * object
-     * @var CharsetConverter
+     * @var AmfphpCharsetConverter
      */
     protected $object;
     
@@ -45,8 +48,8 @@ class AmfphpCharsetConverterTest extends PHPUnit_Framework_TestCase {
      * Sets up the fixture, for example, opens a network connection.
      * This method is called before a test is executed.
      */
-    protected function setUp() {
-        $pluginConfig = array('clientCharset' => 'UTF-8', 'phpCharset' => 'ISO-8859-1', 'method' =>AmfphpCharsetConverter::METHOD_ICONV);
+    protected function setUp(): void {
+        $pluginConfig = array('clientCharset' => 'UTF-8', 'phpCharset' => 'ISO-8859-1', 'method' => AmfphpCharsetConverter::METHOD_ICONV);
         $this->object = new AmfphpCharsetConverter($pluginConfig);
         $this->textInClientCharset = 'éèê'; //utf-8
         $this->textInPhpCharset = iconv('UTF-8', 'ISO-8859-1', $this->textInClientCharset);
@@ -57,7 +60,7 @@ class AmfphpCharsetConverterTest extends PHPUnit_Framework_TestCase {
      * Tears down the fixture, for example, closes a network connection.
      * This method is called after a test is executed.
      */
-    protected function tearDown() {
+    protected function tearDown(): void {
 
     }
     

--- a/Tests/Amfphp/Plugins/AmfphpErrorHandler/AmfphpErrorHandlerTest.php
+++ b/Tests/Amfphp/Plugins/AmfphpErrorHandler/AmfphpErrorHandlerTest.php
@@ -12,6 +12,9 @@
 /**
 *  includes
 *  */
+
+use PHPUnit\Framework\TestCase;
+
 require_once dirname(__FILE__) . '/../../../../Amfphp/Plugins/AmfphpErrorHandler/AmfphpErrorHandler.php';
 require_once dirname(__FILE__) . '/../../../../Amfphp/ClassLoader.php';
 
@@ -20,7 +23,7 @@ require_once dirname(__FILE__) . '/../../../../Amfphp/ClassLoader.php';
  * @package Tests_Amfphp_Plugins_ErrorHandler
  * @author Ariel Sommeria-klein
  */
-class AmfphpErrorHandlerTest extends PHPUnit_Framework_TestCase {
+class AmfphpErrorHandlerTest extends TestCase {
 
     /**
      * object
@@ -33,13 +36,13 @@ class AmfphpErrorHandlerTest extends PHPUnit_Framework_TestCase {
      * Sets up the fixture, for example, opens a network connection.
      * This method is called before a test is executed.
      */
-    protected function setUp() {
+    protected function setUp(): void {
         error_reporting(E_ALL ^ E_USER_NOTICE );
         $this->object = new AmfphpErrorHandler();
         
     }
     
-    protected function tearDown(){
+    protected function tearDown(): void {
         error_reporting(E_ALL);
         
     }
@@ -47,9 +50,9 @@ class AmfphpErrorHandlerTest extends PHPUnit_Framework_TestCase {
 
     /**
      * test trigger error with error level => should throw exception
-     * @expectedException Amfphp_Core_Exception
      * */
     public function testThrows(){
+        $this->expectException(Amfphp_Core_Exception::class);
         trigger_error("oops", E_USER_ERROR);
     }
 

--- a/Tests/Amfphp/Plugins/AmfphpFlexMessaging/AmfphpFlexMessagingTest.php
+++ b/Tests/Amfphp/Plugins/AmfphpFlexMessaging/AmfphpFlexMessagingTest.php
@@ -12,6 +12,9 @@
 /**
  *  includes
  *  */
+
+use PHPUnit\Framework\TestCase;
+
 require_once dirname(__FILE__) . '/../../../../Amfphp/Plugins/AmfphpFlexMessaging/AmfphpFlexMessaging.php';
 require_once dirname(__FILE__) . '/../../../../Amfphp/ClassLoader.php';
 require_once dirname(__FILE__) . '/../../../TestData/TestServicesConfig.php';
@@ -21,11 +24,11 @@ require_once dirname(__FILE__) . '/../../../TestData/TestServicesConfig.php';
  * @package Tests_Amfphp_Plugins_FlexMessaging
  * @author Ariel Sommeria-klein
  */
-class AmfphpFlexMessagingTest extends PHPUnit_Framework_TestCase {
+class AmfphpFlexMessagingTest extends TestCase {
 
     /**
      * object
-     * @var FlexMessaging
+     * @var AmfphpFlexMessaging
      */
     protected $object;
 
@@ -39,7 +42,7 @@ class AmfphpFlexMessagingTest extends PHPUnit_Framework_TestCase {
      * Sets up the fixture, for example, opens a network connection.
      * This method is called before a test is executed.
      */
-    protected function setUp() {
+    protected function setUp(): void {
         $this->object = new AmfphpFlexMessaging();
         $testServiceConfig = new TestServicesConfig();
         $this->serviceRouter = new Amfphp_Core_Common_ServiceRouter($testServiceConfig->serviceFolders, $testServiceConfig->serviceNames2ClassFindInfo);
@@ -49,7 +52,7 @@ class AmfphpFlexMessagingTest extends PHPUnit_Framework_TestCase {
      * Tears down the fixture, for example, closes a network connection.
      * This method is called after a test is executed.
      */
-    protected function tearDown() {
+    protected function tearDown(): void {
         
     }
 

--- a/Tests/Amfphp/Plugins/AmfphpLogger/AmfphpLoggerTest.php
+++ b/Tests/Amfphp/Plugins/AmfphpLogger/AmfphpLoggerTest.php
@@ -12,6 +12,9 @@
 /**
 *  includes
 *  */
+
+use PHPUnit\Framework\TestCase;
+
 require_once dirname(__FILE__) . '/../../../../Amfphp/Plugins/AmfphpLogger/AmfphpLogger.php';
 require_once dirname(__FILE__) . '/../../../../Amfphp/ClassLoader.php';
 
@@ -20,7 +23,7 @@ require_once dirname(__FILE__) . '/../../../../Amfphp/ClassLoader.php';
  * @package Tests_Amfphp_Plugins_Logger
  * @author Ariel Sommeria-klein
  */
-class AmfphpLoggerTest extends PHPUnit_Framework_TestCase {
+class AmfphpLoggerTest extends TestCase {
 
     /**
      * test simple

--- a/Tests/Amfphp/Plugins/AmfphpMonitor/AmfphpMonitorTest.php
+++ b/Tests/Amfphp/Plugins/AmfphpMonitor/AmfphpMonitorTest.php
@@ -12,6 +12,9 @@
 /**
 *  includes
 *  */
+
+use PHPUnit\Framework\TestCase;
+
 require_once dirname(__FILE__) . '/../../../../Amfphp/Plugins/AmfphpMonitor/AmfphpMonitor.php';
 require_once dirname(__FILE__) . '/../../../../Amfphp/ClassLoader.php';
 
@@ -20,11 +23,11 @@ require_once dirname(__FILE__) . '/../../../../Amfphp/ClassLoader.php';
  * @package Tests_Amfphp_Plugins_Monitor
  * @author Ariel Sommeria-klein
  */
-class AmfphpMonitorTest extends PHPUnit_Framework_TestCase {
+class AmfphpMonitorTest extends TestCase {
 
     /**
      * object
-     * @var Monitor
+     * @var AmfphpMonitor
      */
     protected $object;
     
@@ -33,7 +36,7 @@ class AmfphpMonitorTest extends PHPUnit_Framework_TestCase {
      * Sets up the fixture, for example, opens a network connection.
      * This method is called before a test is executed.
      */
-    protected function setUp() {
+    protected function setUp(): void {
         $this->logPath = dirname(__FILE__). '/testlog.txt.php';
         $pluginConfig['maxLogFileSize'] = 20;
         $pluginConfig['logPath'] = $this->logPath;
@@ -46,7 +49,7 @@ class AmfphpMonitorTest extends PHPUnit_Framework_TestCase {
      * Tears down the fixture, for example, closes a network connection.
      * This method is called after a test is executed.
      */
-    protected function tearDown() {
+    protected function tearDown(): void {
        file_put_contents($this->logPath, "<?php exit();?>");
     }
     /**
@@ -66,7 +69,7 @@ class AmfphpMonitorTest extends PHPUnit_Framework_TestCase {
     public function testNoPermission(){
         $pluginConfig['logPath'] = $this->logPath. 'bla';
         $this->object = new AmfphpMonitor($pluginConfig);
-        
+        $this->addToAssertionCount(1);
     }
     
     /**

--- a/Tests/Amfphp/Plugins/AmfphpVoConverter/AmfphpVoConverterTest.php
+++ b/Tests/Amfphp/Plugins/AmfphpVoConverter/AmfphpVoConverterTest.php
@@ -12,6 +12,9 @@
 /**
 *  includes
 *  */
+
+use PHPUnit\Framework\TestCase;
+
 require_once dirname(__FILE__) . '/../../../../Amfphp/Plugins/AmfphpVoConverter/AmfphpVoConverter.php';
 require_once dirname(__FILE__) . '/../../../../Amfphp/ClassLoader.php';
 require_once dirname(__FILE__) . '/../../../TestData/Vo/TestVo1.php';
@@ -22,11 +25,11 @@ require_once dirname(__FILE__) . '/../../../TestData/Vo/TestVo2.php';
  * @package Tests_Amfphp_Plugins_VoConverter
  * @author Ariel Sommeria-klein
  */
-class AmfphpVoConverterTest extends PHPUnit_Framework_TestCase {
+class AmfphpVoConverterTest extends TestCase {
 
     /**
      * object
-     * @var VoConverter
+     * @var AmfphpVoConverter
      */
     protected $object;
 
@@ -34,7 +37,7 @@ class AmfphpVoConverterTest extends PHPUnit_Framework_TestCase {
      * Sets up the fixture, for example, opens a network connection.
      * This method is called before a test is executed.
      */
-    protected function setUp() {
+    protected function setUp(): void {
         $voFolders = array(dirname(__FILE__) . '/../../../TestData/Vo/');
         //add namespace test vo folder
         $voFolders[] = array(dirname(__FILE__). '/../../../TestData/NamespaceVos/', 'NVo');
@@ -47,7 +50,7 @@ class AmfphpVoConverterTest extends PHPUnit_Framework_TestCase {
      * Tears down the fixture, for example, closes a network connection.
      * This method is called after a test is executed.
      */
-    protected function tearDown() {
+    protected function tearDown(): void {
 
     }
     /**
@@ -121,9 +124,9 @@ class AmfphpVoConverterTest extends PHPUnit_Framework_TestCase {
     }
     /**
      * test enforce conversion
-     * @expectedException Amfphp_Core_Exception
      */
     public function testEnforceConversion(){
+        $this->expectException(Amfphp_Core_Exception::class);
         $this->object->enforceConversion = true;
         $explicitTypeField = Amfphp_Core_Amf_Constants::FIELD_EXPLICIT_TYPE;
         $testObj1 = new stdClass();
@@ -132,8 +135,7 @@ class AmfphpVoConverterTest extends PHPUnit_Framework_TestCase {
         $testMessage = new Amfphp_Core_Amf_Message(null, null, array($testObj1));
         $testPacket = new Amfphp_Core_Amf_Packet();
         $testPacket->messages[] = $testMessage;
-        $ret = $this->object->filterDeserializedRequest($testPacket);
-
+        $this->object->filterDeserializedRequest($testPacket);
     }
 
     /**

--- a/Tests/TestData/AmfTestData.php
+++ b/Tests/TestData/AmfTestData.php
@@ -176,7 +176,7 @@ class AmfTestData {
 
     /**
      * reference
-     * @var stdClass
+     * @var int
      */
     public $dReference;
 
@@ -352,13 +352,13 @@ class AmfTestData {
 
     /**
      * test service request packet
-     * @var Amfphp_Core_Amf_Packet
+     * @var String
      */
     public $testServiceRequestPacket;
 
     /**
      * test service request packet
-     * @var Amfphp_Core_Amf_Packet
+     * @var String
      */
     public $testServiceResponsePacket;
 
@@ -504,7 +504,12 @@ class AmfTestData {
      * 
      */
     public function buildObject() {
-        $this->dObject = new stdClass();
+        $this->dObject = new class implements Countable {
+            public function count(): int
+            {
+                return 1;
+            }
+        };
         $this->dObject->firstKey = 'firstValue';
         $this->dObject->secondKey = 'secondValue';
         //type : 3

--- a/Tests/TestData/TestServicesConfig.php
+++ b/Tests/TestData/TestServicesConfig.php
@@ -28,25 +28,12 @@ class TestServicesConfig extends Amfphp_Core_Config {
         $this->serviceFolders[] = dirname(__FILE__) . '/../../Examples/Php/ExampleServices/';
         $testServicePath = dirname(__FILE__) . '/TestService.php';
         $classFindInfo = new Amfphp_Core_Common_ClassFindInfo($testServicePath, 'TestService');
-	$this->serviceNames2ClassFindInfo = array('TestService' => $classFindInfo);
+        $this->serviceNames2ClassFindInfo = array('TestService' => $classFindInfo);
         
         $voFolders = array(AMFPHP_ROOTPATH . 'Services/Vo/', dirname(__FILE__). '/../../Examples/Php/Vo/');
         $voFolders[] = array(dirname(__FILE__). '/NamespaceVos/', 'NVo');
         
         $this->pluginsConfig['AmfphpVoConverter']['voFolders'] = $voFolders;
-        //$this->pluginsConfig['AmfphpVoConverter']['enforceConversion'] = true;
-        
-        //My tests, shouldn't be in release code!!
-        switch(php_uname('s')){
-            case 'Darwin':
-                $this->pluginsFolders[] = '/Users/ariel/Documents/workspaces/baguetteamf/BaguetteAMF/amfphp_plugin/';
-                break;
-            case 'Linux':
-                $this->pluginsFolders[] = '/var/www/baguetteamf/BaguetteAMF/amfphp_plugin/';
-                break;
-            
-        }
-        //$this->serviceFolders [] = '/Users/arielsommeria-klein/Documents/workspaces/baguetteamf/test/Services/';
     }
 
 }

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,4 +1,15 @@
 Version history
+--------- 3.0.0 ---------
+support and requirement for PHP 8.1+
+added phpunit 9.5, fixed tests
+
+
+--------- 2.2.5 ---------
+support for PHP 7.3+
+--------- 2.2.4 ---------
+changed package name to 'silexlabs/amfphp-php-7' from 'silexlabs/amfphp'
+--------- 2.2.3 ---------
+json deserialization fix
 --------- 2.2.2 ---------
 support for php 5.6 and preliminary support for php 7
 better detection of service classes in Amfphp discorvery(for service browser)

--- a/composer.json
+++ b/composer.json
@@ -9,5 +9,12 @@
     ],
     "autoload": {
         "files": ["Amfphp/ClassLoader.php"]
+    },
+    "require": {
+        "php": "^8.1"
+    },
+    "require-dev": {
+        "ext-iconv": "*",
+        "phpunit/phpunit": "^9.5.23"
     }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -1,0 +1,1747 @@
+{
+    "_readme": [
+        "This file locks the dependencies of your project to a known state",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
+        "This file is @generated automatically"
+    ],
+    "content-hash": "9905ca39d4905e108263e5adc2117a14",
+    "packages": [],
+    "packages-dev": [
+        {
+            "name": "doctrine/instantiator",
+            "version": "1.4.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/instantiator.git",
+                "reference": "10dcfce151b967d20fde1b34ae6640712c3891bc"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/10dcfce151b967d20fde1b34ae6640712c3891bc",
+                "reference": "10dcfce151b967d20fde1b34ae6640712c3891bc",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1 || ^8.0"
+            },
+            "require-dev": {
+                "doctrine/coding-standard": "^9",
+                "ext-pdo": "*",
+                "ext-phar": "*",
+                "phpbench/phpbench": "^0.16 || ^1",
+                "phpstan/phpstan": "^1.4",
+                "phpstan/phpstan-phpunit": "^1",
+                "phpunit/phpunit": "^7.5 || ^8.5 || ^9.5",
+                "vimeo/psalm": "^4.22"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Doctrine\\Instantiator\\": "src/Doctrine/Instantiator/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Marco Pivetta",
+                    "email": "ocramius@gmail.com",
+                    "homepage": "https://ocramius.github.io/"
+                }
+            ],
+            "description": "A small, lightweight utility to instantiate objects in PHP without invoking their constructors",
+            "homepage": "https://www.doctrine-project.org/projects/instantiator.html",
+            "keywords": [
+                "constructor",
+                "instantiate"
+            ],
+            "support": {
+                "issues": "https://github.com/doctrine/instantiator/issues",
+                "source": "https://github.com/doctrine/instantiator/tree/1.4.1"
+            },
+            "funding": [
+                {
+                    "url": "https://www.doctrine-project.org/sponsorship.html",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://www.patreon.com/phpdoctrine",
+                    "type": "patreon"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/doctrine%2Finstantiator",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2022-03-03T08:28:38+00:00"
+        },
+        {
+            "name": "myclabs/deep-copy",
+            "version": "1.11.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/myclabs/DeepCopy.git",
+                "reference": "14daed4296fae74d9e3201d2c4925d1acb7aa614"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/14daed4296fae74d9e3201d2c4925d1acb7aa614",
+                "reference": "14daed4296fae74d9e3201d2c4925d1acb7aa614",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1 || ^8.0"
+            },
+            "conflict": {
+                "doctrine/collections": "<1.6.8",
+                "doctrine/common": "<2.13.3 || >=3,<3.2.2"
+            },
+            "require-dev": {
+                "doctrine/collections": "^1.6.8",
+                "doctrine/common": "^2.13.3 || ^3.2.2",
+                "phpunit/phpunit": "^7.5.20 || ^8.5.23 || ^9.5.13"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "src/DeepCopy/deep_copy.php"
+                ],
+                "psr-4": {
+                    "DeepCopy\\": "src/DeepCopy/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Create deep copies (clones) of your objects",
+            "keywords": [
+                "clone",
+                "copy",
+                "duplicate",
+                "object",
+                "object graph"
+            ],
+            "support": {
+                "issues": "https://github.com/myclabs/DeepCopy/issues",
+                "source": "https://github.com/myclabs/DeepCopy/tree/1.11.0"
+            },
+            "funding": [
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/myclabs/deep-copy",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2022-03-03T13:19:32+00:00"
+        },
+        {
+            "name": "nikic/php-parser",
+            "version": "v4.14.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/nikic/PHP-Parser.git",
+                "reference": "34bea19b6e03d8153165d8f30bba4c3be86184c1"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/34bea19b6e03d8153165d8f30bba4c3be86184c1",
+                "reference": "34bea19b6e03d8153165d8f30bba4c3be86184c1",
+                "shasum": ""
+            },
+            "require": {
+                "ext-tokenizer": "*",
+                "php": ">=7.0"
+            },
+            "require-dev": {
+                "ircmaxell/php-yacc": "^0.0.7",
+                "phpunit/phpunit": "^6.5 || ^7.0 || ^8.0 || ^9.0"
+            },
+            "bin": [
+                "bin/php-parse"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.9-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "PhpParser\\": "lib/PhpParser"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Nikita Popov"
+                }
+            ],
+            "description": "A PHP parser written in PHP",
+            "keywords": [
+                "parser",
+                "php"
+            ],
+            "support": {
+                "issues": "https://github.com/nikic/PHP-Parser/issues",
+                "source": "https://github.com/nikic/PHP-Parser/tree/v4.14.0"
+            },
+            "time": "2022-05-31T20:59:12+00:00"
+        },
+        {
+            "name": "phar-io/manifest",
+            "version": "2.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phar-io/manifest.git",
+                "reference": "97803eca37d319dfa7826cc2437fc020857acb53"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phar-io/manifest/zipball/97803eca37d319dfa7826cc2437fc020857acb53",
+                "reference": "97803eca37d319dfa7826cc2437fc020857acb53",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-phar": "*",
+                "ext-xmlwriter": "*",
+                "phar-io/version": "^3.0.1",
+                "php": "^7.2 || ^8.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Arne Blankerts",
+                    "email": "arne@blankerts.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Heuer",
+                    "email": "sebastian@phpeople.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Component for reading phar.io manifest information from a PHP Archive (PHAR)",
+            "support": {
+                "issues": "https://github.com/phar-io/manifest/issues",
+                "source": "https://github.com/phar-io/manifest/tree/2.0.3"
+            },
+            "time": "2021-07-20T11:28:43+00:00"
+        },
+        {
+            "name": "phar-io/version",
+            "version": "3.2.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phar-io/version.git",
+                "reference": "4f7fd7836c6f332bb2933569e566a0d6c4cbed74"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phar-io/version/zipball/4f7fd7836c6f332bb2933569e566a0d6c4cbed74",
+                "reference": "4f7fd7836c6f332bb2933569e566a0d6c4cbed74",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2 || ^8.0"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Arne Blankerts",
+                    "email": "arne@blankerts.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Heuer",
+                    "email": "sebastian@phpeople.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Library for handling version information and constraints",
+            "support": {
+                "issues": "https://github.com/phar-io/version/issues",
+                "source": "https://github.com/phar-io/version/tree/3.2.1"
+            },
+            "time": "2022-02-21T01:04:05+00:00"
+        },
+        {
+            "name": "phpunit/php-code-coverage",
+            "version": "9.2.17",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
+                "reference": "aa94dc41e8661fe90c7316849907cba3007b10d8"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/aa94dc41e8661fe90c7316849907cba3007b10d8",
+                "reference": "aa94dc41e8661fe90c7316849907cba3007b10d8",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-libxml": "*",
+                "ext-xmlwriter": "*",
+                "nikic/php-parser": "^4.14",
+                "php": ">=7.3",
+                "phpunit/php-file-iterator": "^3.0.3",
+                "phpunit/php-text-template": "^2.0.2",
+                "sebastian/code-unit-reverse-lookup": "^2.0.2",
+                "sebastian/complexity": "^2.0",
+                "sebastian/environment": "^5.1.2",
+                "sebastian/lines-of-code": "^1.0.3",
+                "sebastian/version": "^3.0.1",
+                "theseer/tokenizer": "^1.2.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "suggest": {
+                "ext-pcov": "*",
+                "ext-xdebug": "*"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "9.2-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library that provides collection, processing, and rendering functionality for PHP code coverage information.",
+            "homepage": "https://github.com/sebastianbergmann/php-code-coverage",
+            "keywords": [
+                "coverage",
+                "testing",
+                "xunit"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-code-coverage/issues",
+                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/9.2.17"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2022-08-30T12:24:04+00:00"
+        },
+        {
+            "name": "phpunit/php-file-iterator",
+            "version": "3.0.6",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-file-iterator.git",
+                "reference": "cf1c2e7c203ac650e352f4cc675a7021e7d1b3cf"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/cf1c2e7c203ac650e352f4cc675a7021e7d1b3cf",
+                "reference": "cf1c2e7c203ac650e352f4cc675a7021e7d1b3cf",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "FilterIterator implementation that filters files based on a list of suffixes.",
+            "homepage": "https://github.com/sebastianbergmann/php-file-iterator/",
+            "keywords": [
+                "filesystem",
+                "iterator"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-file-iterator/issues",
+                "source": "https://github.com/sebastianbergmann/php-file-iterator/tree/3.0.6"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2021-12-02T12:48:52+00:00"
+        },
+        {
+            "name": "phpunit/php-invoker",
+            "version": "3.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-invoker.git",
+                "reference": "5a10147d0aaf65b58940a0b72f71c9ac0423cc67"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-invoker/zipball/5a10147d0aaf65b58940a0b72f71c9ac0423cc67",
+                "reference": "5a10147d0aaf65b58940a0b72f71c9ac0423cc67",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "ext-pcntl": "*",
+                "phpunit/phpunit": "^9.3"
+            },
+            "suggest": {
+                "ext-pcntl": "*"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.1-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Invoke callables with a timeout",
+            "homepage": "https://github.com/sebastianbergmann/php-invoker/",
+            "keywords": [
+                "process"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-invoker/issues",
+                "source": "https://github.com/sebastianbergmann/php-invoker/tree/3.1.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-09-28T05:58:55+00:00"
+        },
+        {
+            "name": "phpunit/php-text-template",
+            "version": "2.0.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-text-template.git",
+                "reference": "5da5f67fc95621df9ff4c4e5a84d6a8a2acf7c28"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-text-template/zipball/5da5f67fc95621df9ff4c4e5a84d6a8a2acf7c28",
+                "reference": "5da5f67fc95621df9ff4c4e5a84d6a8a2acf7c28",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Simple template engine.",
+            "homepage": "https://github.com/sebastianbergmann/php-text-template/",
+            "keywords": [
+                "template"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-text-template/issues",
+                "source": "https://github.com/sebastianbergmann/php-text-template/tree/2.0.4"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-10-26T05:33:50+00:00"
+        },
+        {
+            "name": "phpunit/php-timer",
+            "version": "5.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-timer.git",
+                "reference": "5a63ce20ed1b5bf577850e2c4e87f4aa902afbd2"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/5a63ce20ed1b5bf577850e2c4e87f4aa902afbd2",
+                "reference": "5a63ce20ed1b5bf577850e2c4e87f4aa902afbd2",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "5.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Utility class for timing",
+            "homepage": "https://github.com/sebastianbergmann/php-timer/",
+            "keywords": [
+                "timer"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-timer/issues",
+                "source": "https://github.com/sebastianbergmann/php-timer/tree/5.0.3"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-10-26T13:16:10+00:00"
+        },
+        {
+            "name": "phpunit/phpunit",
+            "version": "9.5.24",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/phpunit.git",
+                "reference": "d0aa6097bef9fd42458a9b3c49da32c6ce6129c5"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/d0aa6097bef9fd42458a9b3c49da32c6ce6129c5",
+                "reference": "d0aa6097bef9fd42458a9b3c49da32c6ce6129c5",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/instantiator": "^1.3.1",
+                "ext-dom": "*",
+                "ext-json": "*",
+                "ext-libxml": "*",
+                "ext-mbstring": "*",
+                "ext-xml": "*",
+                "ext-xmlwriter": "*",
+                "myclabs/deep-copy": "^1.10.1",
+                "phar-io/manifest": "^2.0.3",
+                "phar-io/version": "^3.0.2",
+                "php": ">=7.3",
+                "phpunit/php-code-coverage": "^9.2.13",
+                "phpunit/php-file-iterator": "^3.0.5",
+                "phpunit/php-invoker": "^3.1.1",
+                "phpunit/php-text-template": "^2.0.3",
+                "phpunit/php-timer": "^5.0.2",
+                "sebastian/cli-parser": "^1.0.1",
+                "sebastian/code-unit": "^1.0.6",
+                "sebastian/comparator": "^4.0.5",
+                "sebastian/diff": "^4.0.3",
+                "sebastian/environment": "^5.1.3",
+                "sebastian/exporter": "^4.0.3",
+                "sebastian/global-state": "^5.0.1",
+                "sebastian/object-enumerator": "^4.0.3",
+                "sebastian/resource-operations": "^3.0.3",
+                "sebastian/type": "^3.1",
+                "sebastian/version": "^3.0.2"
+            },
+            "suggest": {
+                "ext-soap": "*",
+                "ext-xdebug": "*"
+            },
+            "bin": [
+                "phpunit"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "9.5-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "src/Framework/Assert/Functions.php"
+                ],
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "The PHP Unit Testing framework.",
+            "homepage": "https://phpunit.de/",
+            "keywords": [
+                "phpunit",
+                "testing",
+                "xunit"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/phpunit/issues",
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.5.24"
+            },
+            "funding": [
+                {
+                    "url": "https://phpunit.de/sponsors.html",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2022-08-30T07:42:16+00:00"
+        },
+        {
+            "name": "sebastian/cli-parser",
+            "version": "1.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/cli-parser.git",
+                "reference": "442e7c7e687e42adc03470c7b668bc4b2402c0b2"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/cli-parser/zipball/442e7c7e687e42adc03470c7b668bc4b2402c0b2",
+                "reference": "442e7c7e687e42adc03470c7b668bc4b2402c0b2",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library for parsing CLI options",
+            "homepage": "https://github.com/sebastianbergmann/cli-parser",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/cli-parser/issues",
+                "source": "https://github.com/sebastianbergmann/cli-parser/tree/1.0.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-09-28T06:08:49+00:00"
+        },
+        {
+            "name": "sebastian/code-unit",
+            "version": "1.0.8",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/code-unit.git",
+                "reference": "1fc9f64c0927627ef78ba436c9b17d967e68e120"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/code-unit/zipball/1fc9f64c0927627ef78ba436c9b17d967e68e120",
+                "reference": "1fc9f64c0927627ef78ba436c9b17d967e68e120",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Collection of value objects that represent the PHP code units",
+            "homepage": "https://github.com/sebastianbergmann/code-unit",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/code-unit/issues",
+                "source": "https://github.com/sebastianbergmann/code-unit/tree/1.0.8"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-10-26T13:08:54+00:00"
+        },
+        {
+            "name": "sebastian/code-unit-reverse-lookup",
+            "version": "2.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/code-unit-reverse-lookup.git",
+                "reference": "ac91f01ccec49fb77bdc6fd1e548bc70f7faa3e5"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/code-unit-reverse-lookup/zipball/ac91f01ccec49fb77bdc6fd1e548bc70f7faa3e5",
+                "reference": "ac91f01ccec49fb77bdc6fd1e548bc70f7faa3e5",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Looks up which function or method a line of code belongs to",
+            "homepage": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/issues",
+                "source": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/tree/2.0.3"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-09-28T05:30:19+00:00"
+        },
+        {
+            "name": "sebastian/comparator",
+            "version": "4.0.6",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/comparator.git",
+                "reference": "55f4261989e546dc112258c7a75935a81a7ce382"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/55f4261989e546dc112258c7a75935a81a7ce382",
+                "reference": "55f4261989e546dc112258c7a75935a81a7ce382",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3",
+                "sebastian/diff": "^4.0",
+                "sebastian/exporter": "^4.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
+                {
+                    "name": "Jeff Welch",
+                    "email": "whatthejeff@gmail.com"
+                },
+                {
+                    "name": "Volker Dusch",
+                    "email": "github@wallbash.com"
+                },
+                {
+                    "name": "Bernhard Schussek",
+                    "email": "bschussek@2bepublished.at"
+                }
+            ],
+            "description": "Provides the functionality to compare PHP values for equality",
+            "homepage": "https://github.com/sebastianbergmann/comparator",
+            "keywords": [
+                "comparator",
+                "compare",
+                "equality"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/comparator/issues",
+                "source": "https://github.com/sebastianbergmann/comparator/tree/4.0.6"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-10-26T15:49:45+00:00"
+        },
+        {
+            "name": "sebastian/complexity",
+            "version": "2.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/complexity.git",
+                "reference": "739b35e53379900cc9ac327b2147867b8b6efd88"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/complexity/zipball/739b35e53379900cc9ac327b2147867b8b6efd88",
+                "reference": "739b35e53379900cc9ac327b2147867b8b6efd88",
+                "shasum": ""
+            },
+            "require": {
+                "nikic/php-parser": "^4.7",
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library for calculating the complexity of PHP code units",
+            "homepage": "https://github.com/sebastianbergmann/complexity",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/complexity/issues",
+                "source": "https://github.com/sebastianbergmann/complexity/tree/2.0.2"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-10-26T15:52:27+00:00"
+        },
+        {
+            "name": "sebastian/diff",
+            "version": "4.0.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/diff.git",
+                "reference": "3461e3fccc7cfdfc2720be910d3bd73c69be590d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/3461e3fccc7cfdfc2720be910d3bd73c69be590d",
+                "reference": "3461e3fccc7cfdfc2720be910d3bd73c69be590d",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3",
+                "symfony/process": "^4.2 || ^5"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
+                {
+                    "name": "Kore Nordmann",
+                    "email": "mail@kore-nordmann.de"
+                }
+            ],
+            "description": "Diff implementation",
+            "homepage": "https://github.com/sebastianbergmann/diff",
+            "keywords": [
+                "diff",
+                "udiff",
+                "unidiff",
+                "unified diff"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/diff/issues",
+                "source": "https://github.com/sebastianbergmann/diff/tree/4.0.4"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-10-26T13:10:38+00:00"
+        },
+        {
+            "name": "sebastian/environment",
+            "version": "5.1.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/environment.git",
+                "reference": "1b5dff7bb151a4db11d49d90e5408e4e938270f7"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/1b5dff7bb151a4db11d49d90e5408e4e938270f7",
+                "reference": "1b5dff7bb151a4db11d49d90e5408e4e938270f7",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "suggest": {
+                "ext-posix": "*"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "5.1-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Provides functionality to handle HHVM/PHP environments",
+            "homepage": "http://www.github.com/sebastianbergmann/environment",
+            "keywords": [
+                "Xdebug",
+                "environment",
+                "hhvm"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/environment/issues",
+                "source": "https://github.com/sebastianbergmann/environment/tree/5.1.4"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2022-04-03T09:37:03+00:00"
+        },
+        {
+            "name": "sebastian/exporter",
+            "version": "4.0.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/exporter.git",
+                "reference": "65e8b7db476c5dd267e65eea9cab77584d3cfff9"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/65e8b7db476c5dd267e65eea9cab77584d3cfff9",
+                "reference": "65e8b7db476c5dd267e65eea9cab77584d3cfff9",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3",
+                "sebastian/recursion-context": "^4.0"
+            },
+            "require-dev": {
+                "ext-mbstring": "*",
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
+                {
+                    "name": "Jeff Welch",
+                    "email": "whatthejeff@gmail.com"
+                },
+                {
+                    "name": "Volker Dusch",
+                    "email": "github@wallbash.com"
+                },
+                {
+                    "name": "Adam Harvey",
+                    "email": "aharvey@php.net"
+                },
+                {
+                    "name": "Bernhard Schussek",
+                    "email": "bschussek@gmail.com"
+                }
+            ],
+            "description": "Provides the functionality to export PHP variables for visualization",
+            "homepage": "https://www.github.com/sebastianbergmann/exporter",
+            "keywords": [
+                "export",
+                "exporter"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/exporter/issues",
+                "source": "https://github.com/sebastianbergmann/exporter/tree/4.0.4"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2021-11-11T14:18:36+00:00"
+        },
+        {
+            "name": "sebastian/global-state",
+            "version": "5.0.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/global-state.git",
+                "reference": "0ca8db5a5fc9c8646244e629625ac486fa286bf2"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/0ca8db5a5fc9c8646244e629625ac486fa286bf2",
+                "reference": "0ca8db5a5fc9c8646244e629625ac486fa286bf2",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3",
+                "sebastian/object-reflector": "^2.0",
+                "sebastian/recursion-context": "^4.0"
+            },
+            "require-dev": {
+                "ext-dom": "*",
+                "phpunit/phpunit": "^9.3"
+            },
+            "suggest": {
+                "ext-uopz": "*"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "5.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Snapshotting of global state",
+            "homepage": "http://www.github.com/sebastianbergmann/global-state",
+            "keywords": [
+                "global state"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/global-state/issues",
+                "source": "https://github.com/sebastianbergmann/global-state/tree/5.0.5"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2022-02-14T08:28:10+00:00"
+        },
+        {
+            "name": "sebastian/lines-of-code",
+            "version": "1.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/lines-of-code.git",
+                "reference": "c1c2e997aa3146983ed888ad08b15470a2e22ecc"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/lines-of-code/zipball/c1c2e997aa3146983ed888ad08b15470a2e22ecc",
+                "reference": "c1c2e997aa3146983ed888ad08b15470a2e22ecc",
+                "shasum": ""
+            },
+            "require": {
+                "nikic/php-parser": "^4.6",
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library for counting the lines of code in PHP source code",
+            "homepage": "https://github.com/sebastianbergmann/lines-of-code",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/lines-of-code/issues",
+                "source": "https://github.com/sebastianbergmann/lines-of-code/tree/1.0.3"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-11-28T06:42:11+00:00"
+        },
+        {
+            "name": "sebastian/object-enumerator",
+            "version": "4.0.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/object-enumerator.git",
+                "reference": "5c9eeac41b290a3712d88851518825ad78f45c71"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/object-enumerator/zipball/5c9eeac41b290a3712d88851518825ad78f45c71",
+                "reference": "5c9eeac41b290a3712d88851518825ad78f45c71",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3",
+                "sebastian/object-reflector": "^2.0",
+                "sebastian/recursion-context": "^4.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Traverses array structures and object graphs to enumerate all referenced objects",
+            "homepage": "https://github.com/sebastianbergmann/object-enumerator/",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/object-enumerator/issues",
+                "source": "https://github.com/sebastianbergmann/object-enumerator/tree/4.0.4"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-10-26T13:12:34+00:00"
+        },
+        {
+            "name": "sebastian/object-reflector",
+            "version": "2.0.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/object-reflector.git",
+                "reference": "b4f479ebdbf63ac605d183ece17d8d7fe49c15c7"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/object-reflector/zipball/b4f479ebdbf63ac605d183ece17d8d7fe49c15c7",
+                "reference": "b4f479ebdbf63ac605d183ece17d8d7fe49c15c7",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Allows reflection of object attributes, including inherited and non-public ones",
+            "homepage": "https://github.com/sebastianbergmann/object-reflector/",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/object-reflector/issues",
+                "source": "https://github.com/sebastianbergmann/object-reflector/tree/2.0.4"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-10-26T13:14:26+00:00"
+        },
+        {
+            "name": "sebastian/recursion-context",
+            "version": "4.0.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/recursion-context.git",
+                "reference": "cd9d8cf3c5804de4341c283ed787f099f5506172"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/cd9d8cf3c5804de4341c283ed787f099f5506172",
+                "reference": "cd9d8cf3c5804de4341c283ed787f099f5506172",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
+                {
+                    "name": "Jeff Welch",
+                    "email": "whatthejeff@gmail.com"
+                },
+                {
+                    "name": "Adam Harvey",
+                    "email": "aharvey@php.net"
+                }
+            ],
+            "description": "Provides functionality to recursively process PHP variables",
+            "homepage": "http://www.github.com/sebastianbergmann/recursion-context",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/recursion-context/issues",
+                "source": "https://github.com/sebastianbergmann/recursion-context/tree/4.0.4"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-10-26T13:17:30+00:00"
+        },
+        {
+            "name": "sebastian/resource-operations",
+            "version": "3.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/resource-operations.git",
+                "reference": "0f4443cb3a1d92ce809899753bc0d5d5a8dd19a8"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/resource-operations/zipball/0f4443cb3a1d92ce809899753bc0d5d5a8dd19a8",
+                "reference": "0f4443cb3a1d92ce809899753bc0d5d5a8dd19a8",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Provides a list of PHP built-in functions that operate on resources",
+            "homepage": "https://www.github.com/sebastianbergmann/resource-operations",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/resource-operations/issues",
+                "source": "https://github.com/sebastianbergmann/resource-operations/tree/3.0.3"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-09-28T06:45:17+00:00"
+        },
+        {
+            "name": "sebastian/type",
+            "version": "3.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/type.git",
+                "reference": "fb44e1cc6e557418387ad815780360057e40753e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/type/zipball/fb44e1cc6e557418387ad815780360057e40753e",
+                "reference": "fb44e1cc6e557418387ad815780360057e40753e",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.5"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.1-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Collection of value objects that represent the types of the PHP type system",
+            "homepage": "https://github.com/sebastianbergmann/type",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/type/issues",
+                "source": "https://github.com/sebastianbergmann/type/tree/3.1.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2022-08-29T06:55:37+00:00"
+        },
+        {
+            "name": "sebastian/version",
+            "version": "3.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/version.git",
+                "reference": "c6c1022351a901512170118436c764e473f6de8c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/version/zipball/c6c1022351a901512170118436c764e473f6de8c",
+                "reference": "c6c1022351a901512170118436c764e473f6de8c",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library that helps with managing the version number of Git-hosted PHP projects",
+            "homepage": "https://github.com/sebastianbergmann/version",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/version/issues",
+                "source": "https://github.com/sebastianbergmann/version/tree/3.0.2"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-09-28T06:39:44+00:00"
+        },
+        {
+            "name": "theseer/tokenizer",
+            "version": "1.2.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/theseer/tokenizer.git",
+                "reference": "34a41e998c2183e22995f158c581e7b5e755ab9e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/theseer/tokenizer/zipball/34a41e998c2183e22995f158c581e7b5e755ab9e",
+                "reference": "34a41e998c2183e22995f158c581e7b5e755ab9e",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-tokenizer": "*",
+                "ext-xmlwriter": "*",
+                "php": "^7.2 || ^8.0"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Arne Blankerts",
+                    "email": "arne@blankerts.de",
+                    "role": "Developer"
+                }
+            ],
+            "description": "A small library for converting tokenized PHP source code into XML and potentially other formats",
+            "support": {
+                "issues": "https://github.com/theseer/tokenizer/issues",
+                "source": "https://github.com/theseer/tokenizer/tree/1.2.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/theseer",
+                    "type": "github"
+                }
+            ],
+            "time": "2021-07-28T10:34:58+00:00"
+        }
+    ],
+    "aliases": [],
+    "minimum-stability": "stable",
+    "stability-flags": [],
+    "prefer-stable": false,
+    "prefer-lowest": false,
+    "platform": {
+        "php": "^8.1"
+    },
+    "platform-dev": [],
+    "plugin-api-version": "2.3.0"
+}


### PR DESCRIPTION
Explicitly requiring PHP 8.1 or newer.
Fixed tests to support PHPUnit 9.5.
Removed error context parameter from AmfphpErrorHandler.